### PR TITLE
Add encodeMany

### DIFF
--- a/src/Pipes/Binary.hs
+++ b/src/Pipes/Binary.hs
@@ -7,6 +7,7 @@
 module Pipes.Binary
   ( -- * @Binary@ instances
     encode
+  , encodeMany
   , decode
   , decodeMany
     -- * @Get@ monad


### PR DESCRIPTION
`encodeMany` is the pipe version of `encode`. It continuously reads from upstream, and sends ByteString-encoded data downstream.

Simple example use case: a chat (sending) client. To keep it simple the networking has been removed, so it's just printing the message and its encoded version.

``` haskell
module Main (main) where

import Pipes
import Data.Binary (Binary)
import qualified Data.ByteString as BS
import qualified Pipes.Prelude as P
import qualified Pipes.Binary as P



main :: IO ()
main = do
      putStrLn "encodeMany demonstration"
      putStrLn "Enter \"quit\" to quit"
      runEffect $ P.stdinLn >-> handle >-> encodeMany >-> send



handle :: Pipe String String IO ()
handle = P.takeWhile (/= "quit") >-> P.mapM dispatch
      where dispatch :: String -> IO String
            dispatch msg = do
                  putStrLn $ "Message: \"" ++ msg ++ "\""
                  return msg



-- | Continuously encodes the given 'Bin.Binary' instance and sends each result
--   downstream in 'BS.ByteString' chunks.
encodeMany :: (Monad m, Binary x) => Pipe x BS.ByteString m r
encodeMany = for cat P.encode



send :: (MonadIO io) => Consumer BS.ByteString io ()
send = P.show >-> P.stdoutLn
```
