### PR TITLE
Make `decoded` and `decodedL` a `Lens'` instead of an `Iso'` as part of #12

### DIFF
--- a/pipes-binary.cabal
+++ b/pipes-binary.cabal
@@ -35,7 +35,6 @@ library
         , pipes            >= 4.0     && < 4.2
         , pipes-parse      >= 3.0     && < 3.1
         , pipes-bytestring >= 2.0     && < 2.1
-        , profunctors      >= 3.1.1   && < 4.1
         , transformers     >= 0.2     && < 0.4
 
 test-suite tests

--- a/src/Pipes/Binary.hs
+++ b/src/Pipes/Binary.hs
@@ -7,7 +7,7 @@
 -- @lens-family@ and @lens-family-core@ libraries is used but not exported:
 --
 -- @
--- type Iso' a b = forall f p. ('Functor' f, 'Profunctor' p) => p b (f b) -> p a (f a)
+-- type Lens' a b = forall f . Functor f => (b -> f b) -> (a -> f a)
 -- @
 
 {-# LANGUAGE DeriveDataTypeable #-}
@@ -57,7 +57,6 @@ import qualified Data.Binary.Put                  as Put
 import           Data.ByteString                  (ByteString)
 import qualified Data.ByteString                  as B
 import           Data.Data                        (Data, Typeable)
-import           Data.Profunctor                  (Profunctor, dimap)
 import           GHC.Generics                     (Generic)
 import           Pipes
 import qualified Pipes.ByteString
@@ -65,7 +64,7 @@ import           Pipes.Parse                      (Parser)
 
 --------------------------------------------------------------------------------
 
-type Iso' a b = forall f p. (Functor f, Profunctor p) => p b (f b) -> p a (f a)
+type Lens' a b = forall f . Functor f => (b -> f b) -> (a -> f a)
 
 --------------------------------------------------------------------------------
 
@@ -94,12 +93,12 @@ decode = do
        Right (_, a) -> Right a)
 {-# INLINABLE decode #-}
 
--- | An isomorphism between a stream of bytes and a stream of decoded values.
+-- | Improper lens that turns a stream of bytes into a stream of decoded values.
 decoded
   :: (Monad m, Binary a)
-  => Iso' (Producer ByteString m r)
-          (Producer a m (Either (DecodingError, Producer ByteString m r) r))
-decoded = dimap _decode (fmap _encode)
+  => Lens' (Producer ByteString m r)
+           (Producer a m (Either (DecodingError, Producer ByteString m r) r))
+decoded k p = fmap _encode (k (_decode p))
   where
     _decode p0 = do
       (mr, p1) <- lift (S.runStateT isEndOfBytes' p0)
@@ -131,10 +130,10 @@ decodeL = decodeGetL get
 -- input consumed in order to decode it.
 decodedL
   :: (Monad m, Binary a)
-  => Iso' (Producer ByteString m r)
-          (Producer (ByteOffset, a) m
-                    (Either (DecodingError, Producer ByteString m r) r))
-decodedL = dimap _decode (fmap _encode)
+  => Lens' (Producer ByteString m r)
+           (Producer (ByteOffset, a) m
+                     (Either (DecodingError, Producer ByteString m r) r))
+decodedL k p = fmap _encode (k (_decode p))
   where
     _decode p0 = do
       (mr, p1) <- lift (S.runStateT isEndOfBytes' p0)


### PR DESCRIPTION
I was about to try to write `encoder` but I see in #13 that @Gabriel439 is working on it.
