### PR TITLE
Update pipes-binary.cabal

### DIFF
--- a/pipes-binary.cabal
+++ b/pipes-binary.cabal
@@ -34,7 +34,7 @@ library
         , ghc-prim
         , pipes            >= 4.0     && < 4.2
         , pipes-parse      >= 3.0     && < 3.1
-        , pipes-bytestring >= 2.0     && < 2.1
+        , pipes-bytestring >= 2.0     && < 2.2
         , transformers     >= 0.2     && < 0.4
 
 test-suite tests


### PR DESCRIPTION
The new `pipes-bytestring` is 2.1.0; `pipes-binary` compiles and passes the test if I move the constraints up.
