### PR TITLE
Add CPP to handle the removal of Control.Monad.Trans.Error

### DIFF
--- a/src/Pipes/Binary.hs
+++ b/src/Pipes/Binary.hs
@@ -10,6 +10,7 @@
 -- type Lens' a b = forall f . 'Functor' f => (b -> f b) -> (a -> f a)
 -- @
 
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE RankNTypes         #-}
@@ -46,7 +47,9 @@ module Pipes.Binary (
   ) where
 
 import           Control.Exception                (Exception)
+#if !MIN_VERSION_transformers(0,6,0)
 import           Control.Monad.Trans.Error        (Error)
+#endif
 import qualified Control.Monad.Trans.State.Strict as S
 import           Data.Binary                      (Binary (..))
 import qualified Data.Binary
@@ -222,7 +225,9 @@ data DecodingError = DecodingError
   } deriving (Show, Read, Eq, Data, Typeable, Generic)
 
 instance Exception DecodingError
+#if !MIN_VERSION_transformers(0,6,0)
 instance Error     DecodingError
+#endif
 
 --------------------------------------------------------------------------------
 -- Internal stuff


### PR DESCRIPTION
This keeps the instance of `Error` if compiled with an older transformers, but removes it for the latest versions.

All older releases should get a revision with the upperbound `transformer < 0.6.0` to be unbuildable.

Fixes #29